### PR TITLE
bypasses an error in Ubuntu 15.10

### DIFF
--- a/panelswitcher.plugin
+++ b/panelswitcher.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=panelswitcher
 IAge=3
 Name=Panel Switcher


### PR DESCRIPTION
Otherwise, you get an error that says

```
Plugin loader 'python' was not found.
```
